### PR TITLE
Rename "CodeRacer" to "BalapKode"

### DIFF
--- a/lib/coderacer_web/components/layouts/root.html.heex
+++ b/lib/coderacer_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="CodeRacer" suffix=" · Modern Code Typing">
+    <.live_title default="BalapKode" suffix=" · Modern Code Typing">
       {assigns[:page_title]}
     </.live_title>
     
@@ -13,7 +13,7 @@
       <!-- Open Graph / Facebook -->
       <meta property="og:type" content="website" />
       <meta property="og:url" content={assigns[:share_url]} />
-      <meta property="og:title" content={assigns[:page_title] || "CodeRacer"} />
+      <meta property="og:title" content={assigns[:page_title] || "BalapKode"} />
       <meta property="og:description" content={assigns[:share_description]} />
       <meta property="og:image" content={assigns[:og_image_url]} />
       <meta property="og:image:width" content="1200" />
@@ -22,26 +22,26 @@
 <!-- Twitter -->
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content={assigns[:share_url]} />
-      <meta property="twitter:title" content={assigns[:page_title] || "CodeRacer"} />
+      <meta property="twitter:title" content={assigns[:page_title] || "BalapKode"} />
       <meta property="twitter:description" content={assigns[:share_description]} />
       <meta property="twitter:image" content={assigns[:og_image_url]} />
     <% else %>
       <!-- Default Meta Tags -->
       <meta
         name="description"
-        content="Test your coding typing speed and accuracy with CodeRacer. Challenge yourself with real code snippets in 20+ programming languages."
+        content="Test your coding typing speed and accuracy with BalapKode. Challenge yourself with real code snippets in 20+ programming languages."
       />
       <meta property="og:type" content="website" />
-      <meta property="og:title" content="CodeRacer - Modern Code Typing" />
+      <meta property="og:title" content="BalapKode - Modern Code Typing" />
       <meta
         property="og:description"
-        content="Test your coding typing speed and accuracy with CodeRacer. Challenge yourself with real code snippets in 20+ programming languages."
+        content="Test your coding typing speed and accuracy with BalapKode. Challenge yourself with real code snippets in 20+ programming languages."
       />
       <meta property="twitter:card" content="summary" />
-      <meta property="twitter:title" content="CodeRacer - Modern Code Typing" />
+      <meta property="twitter:title" content="BalapKode - Modern Code Typing" />
       <meta
         property="twitter:description"
-        content="Test your coding typing speed and accuracy with CodeRacer. Challenge yourself with real code snippets in 20+ programming languages."
+        content="Test your coding typing speed and accuracy with BalapKode. Challenge yourself with real code snippets in 20+ programming languages."
       />
     <% end %>
     
@@ -86,7 +86,7 @@
       <footer class="text-center py-6 text-muted border-t border-gray-800">
         <p class="text-sm">
           Built with ❤️ using Elixir & Phoenix •
-          <span class="text-brand-primary font-medium">CodeRacer</span>
+          <span class="text-brand-primary font-medium">BalapKode</span>
           •
           <a href="/leaderboard" class="text-yellow-400 hover:text-yellow-300 transition-colors">
             🏆 Leaderboard
@@ -98,8 +98,8 @@
       function sharePerformance(cpm, accuracy, time_completion, wrong, language, difficulty) {
         const shareUrl = window.location.href.replace("/finish/", "/share/")
         const shareData = {
-          title: 'CodeRacer Challenge Results 🏆',
-          text: `I just completed a coding challenge on CodeRacer!\n\n🎯 Results:\n• ${cpm} Characters/Min\n• ${accuracy}% Accuracy\n• ${time_completion}s Time Taken\n• ${wrong} Errors\n\nLanguage: ${language.toUpperCase()}\nDifficulty: ${difficulty.toUpperCase()}\n\nTry your own coding challenge at CodeRacer!`,
+          title: 'BalapKode Challenge Results 🏆',
+          text: `I just completed a coding challenge on BalapKode!\n\n🎯 Results:\n• ${cpm} Characters/Min\n• ${accuracy}% Accuracy\n• ${time_completion}s Time Taken\n• ${wrong} Errors\n\nLanguage: ${language.toUpperCase()}\nDifficulty: ${difficulty.toUpperCase()}\n\nTry your own coding challenge at BalapKode!`,
           url: shareUrl
         };
 

--- a/lib/coderacer_web/live/game/game_live.html.heex
+++ b/lib/coderacer_web/live/game/game_live.html.heex
@@ -11,7 +11,7 @@
 <div class="w-full max-w-6xl mx-auto">
   <!-- Header -->
   <div class="text-center mb-8">
-    <h1 class="text-4xl font-bold text-gradient mb-2">CodeRacer</h1>
+    <h1 class="text-4xl font-bold text-gradient mb-2">BalapKode</h1>
     <div class="flex items-center justify-center space-x-4 text-muted">
       <span class="text-sm">
         Language:

--- a/lib/coderacer_web/live/share/share_live.ex
+++ b/lib/coderacer_web/live/share/share_live.ex
@@ -36,7 +36,7 @@ defmodule CoderacerWeb.ShareLive do
         difficulty = game_session.difficulty |> to_string() |> String.capitalize()
 
         share_description =
-          "I scored #{cpm} CPM with #{accuracy}% accuracy in #{language} (#{difficulty}) on CodeRacer! Can you beat my score?"
+          "I scored #{cpm} CPM with #{accuracy}% accuracy in #{language} (#{difficulty}) on BalapKode! Can you beat my score?"
 
         # Set up meta tags for social sharing
         og_image_url = url(socket, ~p"/og-image/#{id}")
@@ -48,7 +48,7 @@ defmodule CoderacerWeb.ShareLive do
           |> assign(:cpm, cpm)
           |> assign(:accuracy, accuracy)
           |> assign(:is_likely_owner, is_likely_owner)
-          |> assign(:page_title, "CodeRacer Results - #{cpm} CPM, #{accuracy}% Accuracy")
+          |> assign(:page_title, "BalapKode Results - #{cpm} CPM, #{accuracy}% Accuracy")
           |> assign(:share_description, share_description)
           |> assign(:og_image_url, og_image_url)
           |> assign(:share_url, share_url)

--- a/lib/coderacer_web/live/share/share_live.html.heex
+++ b/lib/coderacer_web/live/share/share_live.html.heex
@@ -5,7 +5,7 @@
     <!-- Header -->
     <div class="text-center mb-12">
       <div class="text-6xl mb-6">🚀</div>
-      <h1 class="text-5xl font-bold text-gradient mb-4">CodeRacer Results</h1>
+      <h1 class="text-5xl font-bold text-gradient mb-4">BalapKode Results</h1>
       <p class="text-xl text-muted">Check out this coding challenge performance!</p>
     </div>
     

--- a/lib/coderacer_web/live/share_leaderboard/share_leaderboard_live.ex
+++ b/lib/coderacer_web/live/share_leaderboard/share_leaderboard_live.ex
@@ -55,8 +55,8 @@ defmodule CoderacerWeb.ShareLeaderboardLive do
           <.live_component
             module={CoderacerWeb.Live.Components.ShareButton}
             id="share-leaderboard"
-            share_title="CodeRacer Leaderboard 🏆"
-            share_text="Check out this CodeRacer leaderboard! 🏆"
+            share_title="BalapKode Leaderboard 🏆"
+            share_text="Check out this BalapKode leaderboard! 🏆"
             share_url={@share_url}
           />
         </div>
@@ -175,32 +175,32 @@ defmodule CoderacerWeb.ShareLeaderboardLive do
   defp generate_page_title(view_type, language, difficulty) do
     case view_type do
       "language" when not is_nil(language) ->
-        "#{String.capitalize(language)} Leaderboard - CodeRacer"
+        "#{String.capitalize(language)} Leaderboard - BalapKode"
 
       "difficulty" when not is_nil(difficulty) ->
-        "#{format_difficulty(difficulty)} Difficulty Leaderboard - CodeRacer"
+        "#{format_difficulty(difficulty)} Difficulty Leaderboard - BalapKode"
 
       "combined" when not is_nil(language) and not is_nil(difficulty) ->
-        "#{String.capitalize(language)} (#{format_difficulty(difficulty)}) Leaderboard - CodeRacer"
+        "#{String.capitalize(language)} (#{format_difficulty(difficulty)}) Leaderboard - BalapKode"
 
       _ ->
-        "Global Leaderboard - CodeRacer"
+        "Global Leaderboard - BalapKode"
     end
   end
 
   defp generate_share_description(view_type, language, difficulty) do
     case view_type do
       "language" when not is_nil(language) ->
-        "Check out the top #{String.capitalize(language)} coding speed champions on CodeRacer! 🏆 See who dominates the leaderboard."
+        "Check out the top #{String.capitalize(language)} coding speed champions on BalapKode! 🏆 See who dominates the leaderboard."
 
       "difficulty" when not is_nil(difficulty) ->
-        "Check out the top #{format_difficulty(difficulty)} difficulty coding speed champions on CodeRacer! 🏆 See who dominates the leaderboard."
+        "Check out the top #{format_difficulty(difficulty)} difficulty coding speed champions on BalapKode! 🏆 See who dominates the leaderboard."
 
       "combined" when not is_nil(language) and not is_nil(difficulty) ->
-        "Check out the top #{String.capitalize(language)} (#{format_difficulty(difficulty)}) coding speed champions on CodeRacer! 🏆 See who dominates the leaderboard."
+        "Check out the top #{String.capitalize(language)} (#{format_difficulty(difficulty)}) coding speed champions on BalapKode! 🏆 See who dominates the leaderboard."
 
       _ ->
-        "Check out the top coding speed champions on CodeRacer! 🏆 See who dominates the global leaderboard."
+        "Check out the top coding speed champions on BalapKode! 🏆 See who dominates the global leaderboard."
     end
   end
 

--- a/lib/coderacer_web/live/start/start_live.html.heex
+++ b/lib/coderacer_web/live/start/start_live.html.heex
@@ -2,7 +2,7 @@
   <!-- Hero Section -->
   <div class="text-center mb-12">
     <h1 class="text-6xl font-bold text-gradient mb-4 typing-cursor">
-      CodeRacer
+      BalapKode
     </h1>
     <p class="text-xl text-muted max-w-lg mx-auto">
       Tab-completion made you lazy? It's time to get your typing speed back!

--- a/test/coderacer_web/live/finish_live_test.exs
+++ b/test/coderacer_web/live/finish_live_test.exs
@@ -23,6 +23,8 @@ defmodule CoderacerWeb.FinishLiveTest do
 
       assert html =~ "Challenge Complete!"
       assert html =~ "Well done on completing the coding challenge"
+      assert html =~ "BalapKode"
+      refute html =~ "CodeRacer"
     end
 
     test "displays performance statistics using component", %{conn: conn, session: session} do

--- a/test/coderacer_web/live/game_live_test.exs
+++ b/test/coderacer_web/live/game_live_test.exs
@@ -17,7 +17,8 @@ defmodule CoderacerWeb.GameLiveTest do
       {:ok, _view, html} = live(conn, "/game/#{session.id}")
       assert html =~ "Time"
       assert html =~ "0s"
-      assert html =~ "CodeRacer"
+      refute html =~ "CodeRacer"
+      assert html =~ "BalapKode"
     end
 
     test "starts stopwatch on first character input", %{conn: conn, session: session} do

--- a/test/coderacer_web/live/leaderboard_live_test.exs
+++ b/test/coderacer_web/live/leaderboard_live_test.exs
@@ -12,39 +12,50 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
       assert html =~ "No Entries Yet"
       assert html =~ "Be the first to set a record!"
       assert html =~ "Start Playing"
+      assert html =~ "BalapKode"
+      refute html =~ "CodeRacer"
     end
 
     test "renders global leaderboard with entries", %{conn: conn} do
       # Create test entries
-      _entry1 = leaderboard_entry_fixture(%{
-        player_name: "Alice",
-        cpm: 50,
-        accuracy: 95,
-        language: "JavaScript",
-        difficulty: :easy
-      })
+      _entry1 =
+        leaderboard_entry_fixture(%{
+          player_name: "Alice",
+          cpm: 50,
+          accuracy: 95,
+          language: "JavaScript",
+          difficulty: :easy
+        })
 
-      _entry2 = leaderboard_entry_fixture(%{
-        player_name: "Bob",
-        cpm: 45,
-        accuracy: 90,
-        language: "Python",
-        difficulty: :medium
-      })
+      _entry2 =
+        leaderboard_entry_fixture(%{
+          player_name: "Bob",
+          cpm: 45,
+          accuracy: 90,
+          language: "Python",
+          difficulty: :medium
+        })
 
       {:ok, _view, html} = live(conn, "/leaderboard")
 
       assert html =~ "Leaderboard"
       assert html =~ "Alice"
       assert html =~ "Bob"
-      assert html =~ "50" # CPM
-      assert html =~ "45" # CPM
-      assert html =~ "95%" # Accuracy
-      assert html =~ "90%" # Accuracy
-      assert html =~ "Javascript" # Capitalized
+      # CPM
+      assert html =~ "50"
+      # CPM
+      assert html =~ "45"
+      # Accuracy
+      assert html =~ "95%"
+      # Accuracy
+      assert html =~ "90%"
+      # Capitalized
+      assert html =~ "Javascript"
       assert html =~ "Python"
-      assert html =~ "badge-warning" # First place gold
-      assert html =~ "badge-info" # Second place silver
+      # First place gold
+      assert html =~ "badge-warning"
+      # Second place silver
+      assert html =~ "badge-info"
     end
 
     test "displays ranking badges correctly", %{conn: conn} do
@@ -56,17 +67,22 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
 
       {:ok, _view, html} = live(conn, "/leaderboard")
 
-      assert html =~ "badge-warning" # Gold medal
-      assert html =~ "badge-info" # Silver medal
-      assert html =~ "badge-accent" # Bronze medal
-      assert html =~ "#4" # Numeric rank
+      # Gold medal
+      assert html =~ "badge-warning"
+      # Silver medal
+      assert html =~ "badge-info"
+      # Bronze medal
+      assert html =~ "badge-accent"
+      # Numeric rank
+      assert html =~ "#4"
     end
 
     test "switches to language view", %{conn: conn} do
-      _entry = leaderboard_entry_fixture(%{
-        player_name: "JS Developer",
-        language: "JavaScript"
-      })
+      _entry =
+        leaderboard_entry_fixture(%{
+          player_name: "JS Developer",
+          language: "JavaScript"
+        })
 
       {:ok, view, _html} = live(conn, "/leaderboard")
 
@@ -78,17 +94,19 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "filters by specific language", %{conn: conn} do
-      _js_entry = leaderboard_entry_fixture(%{
-        player_name: "JS Dev",
-        language: "JavaScript",
-        cpm: 50
-      })
+      _js_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "JS Dev",
+          language: "JavaScript",
+          cpm: 50
+        })
 
-      _py_entry = leaderboard_entry_fixture(%{
-        player_name: "Python Dev",
-        language: "Python",
-        cpm: 45
-      })
+      _py_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Python Dev",
+          language: "Python",
+          cpm: 45
+        })
 
       {:ok, view, _html} = live(conn, "/leaderboard")
 
@@ -106,17 +124,19 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "filters by difficulty", %{conn: conn} do
-      _easy_entry = leaderboard_entry_fixture(%{
-        player_name: "Easy Player",
-        difficulty: :easy,
-        cpm: 50
-      })
+      _easy_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Easy Player",
+          difficulty: :easy,
+          cpm: 50
+        })
 
-      _hard_entry = leaderboard_entry_fixture(%{
-        player_name: "Hard Player",
-        difficulty: :hard,
-        cpm: 45
-      })
+      _hard_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Hard Player",
+          difficulty: :hard,
+          cpm: 45
+        })
 
       {:ok, view, _html} = live(conn, "/leaderboard")
 
@@ -134,11 +154,12 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "handles params on mount", %{conn: conn} do
-      _entry = leaderboard_entry_fixture(%{
-        player_name: "Test Player",
-        language: "JavaScript",
-        difficulty: :medium
-      })
+      _entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Test Player",
+          language: "JavaScript",
+          difficulty: :medium
+        })
 
       # Mount with language filter
       {:ok, _view, html} = live(conn, "/leaderboard?view=language&language=JavaScript")
@@ -148,10 +169,11 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "handles params with difficulty filter", %{conn: conn} do
-      _entry = leaderboard_entry_fixture(%{
-        player_name: "Medium Player",
-        difficulty: :medium
-      })
+      _entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Medium Player",
+          difficulty: :medium
+        })
 
       # Mount with difficulty filter
       {:ok, _view, html} = live(conn, "/leaderboard?view=difficulty&difficulty=medium")
@@ -168,7 +190,8 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
       {:ok, _view, html} = live(conn, "/leaderboard")
 
       assert html =~ "By Language"
-      assert html =~ "Javascript" # Capitalized
+      # Capitalized
+      assert html =~ "Javascript"
       assert html =~ "Python"
       assert html =~ "Elixir"
     end
@@ -202,26 +225,32 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "displays correct difficulty badges", %{conn: conn} do
-      _easy_entry = leaderboard_entry_fixture(%{
-        player_name: "Easy Player",
-        difficulty: :easy
-      })
+      _easy_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Easy Player",
+          difficulty: :easy
+        })
 
-      _medium_entry = leaderboard_entry_fixture(%{
-        player_name: "Medium Player",
-        difficulty: :medium
-      })
+      _medium_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Medium Player",
+          difficulty: :medium
+        })
 
-      _hard_entry = leaderboard_entry_fixture(%{
-        player_name: "Hard Player",
-        difficulty: :hard
-      })
+      _hard_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Hard Player",
+          difficulty: :hard
+        })
 
       {:ok, _view, html} = live(conn, "/leaderboard")
 
-      assert html =~ "badge-success" # Easy
-      assert html =~ "badge-warning" # Medium
-      assert html =~ "badge-error" # Hard
+      # Easy
+      assert html =~ "badge-success"
+      # Medium
+      assert html =~ "badge-warning"
+      # Hard
+      assert html =~ "badge-error"
     end
 
     test "formats dates correctly", %{conn: conn} do
@@ -265,23 +294,26 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "displays entries in correct order by CPM", %{conn: conn} do
-      _entry1 = leaderboard_entry_fixture(%{
-        player_name: "Slow",
-        cpm: 30,
-        accuracy: 95
-      })
+      _entry1 =
+        leaderboard_entry_fixture(%{
+          player_name: "Slow",
+          cpm: 30,
+          accuracy: 95
+        })
 
-      _entry2 = leaderboard_entry_fixture(%{
-        player_name: "Fast",
-        cpm: 60,
-        accuracy: 85
-      })
+      _entry2 =
+        leaderboard_entry_fixture(%{
+          player_name: "Fast",
+          cpm: 60,
+          accuracy: 85
+        })
 
-      _entry3 = leaderboard_entry_fixture(%{
-        player_name: "Medium",
-        cpm: 45,
-        accuracy: 90
-      })
+      _entry3 =
+        leaderboard_entry_fixture(%{
+          player_name: "Medium",
+          cpm: 45,
+          accuracy: 90
+        })
 
       {:ok, _view, html} = live(conn, "/leaderboard")
 
@@ -321,19 +353,22 @@ defmodule CoderacerWeb.LeaderboardLiveTest do
     end
 
     test "handles combined language and difficulty filter", %{conn: conn} do
-      _matching_entry = leaderboard_entry_fixture(%{
-        player_name: "Perfect Match",
-        language: "JavaScript",
-        difficulty: :hard
-      })
+      _matching_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Perfect Match",
+          language: "JavaScript",
+          difficulty: :hard
+        })
 
-      _non_matching_entry = leaderboard_entry_fixture(%{
-        player_name: "Wrong Lang",
-        language: "Python",
-        difficulty: :hard
-      })
+      _non_matching_entry =
+        leaderboard_entry_fixture(%{
+          player_name: "Wrong Lang",
+          language: "Python",
+          difficulty: :hard
+        })
 
-      {:ok, _view, html} = live(conn, "/leaderboard?view=combined&language=JavaScript&difficulty=hard")
+      {:ok, _view, html} =
+        live(conn, "/leaderboard?view=combined&language=JavaScript&difficulty=hard")
 
       assert html =~ "Perfect Match"
       refute html =~ "Wrong Lang"

--- a/test/coderacer_web/live/share_leaderboard_live_test.exs
+++ b/test/coderacer_web/live/share_leaderboard_live_test.exs
@@ -43,14 +43,16 @@ defmodule CoderacerWeb.ShareLeaderboardLiveTest do
       assert html =~ "Top coding speed champions"
       assert html =~ "Think You Can Beat These Scores?"
       assert html =~ "Start Your Challenge"
+      assert html =~ "BalapKode"
+      refute html =~ "CodeRacer"
     end
 
     test "assigns correct Open Graph meta data for global leaderboard", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/share/leaderboard")
 
       # Check meta tags in the HTML
-      assert html =~ "Global Leaderboard - CodeRacer"
-      assert html =~ "Check out the top coding speed champions on CodeRacer!"
+      assert html =~ "Global Leaderboard - BalapKode"
+      assert html =~ "Check out the top coding speed champions on BalapKode!"
       assert html =~ "/share/leaderboard?view=global"
       assert html =~ "/og-image/leaderboard?view=global"
     end
@@ -66,7 +68,7 @@ defmodule CoderacerWeb.ShareLeaderboardLiveTest do
       {:ok, _view, html} = live(conn, "/share/leaderboard?view=language&language=elixir")
 
       # Check meta tags in the HTML
-      assert html =~ "Elixir Leaderboard - CodeRacer"
+      assert html =~ "Elixir Leaderboard - BalapKode"
       assert html =~ "Check out the top Elixir coding speed champions"
       assert html =~ "/share/leaderboard?view=language&amp;language=elixir"
       assert html =~ "/og-image/leaderboard?view=language&amp;language=elixir"
@@ -83,7 +85,7 @@ defmodule CoderacerWeb.ShareLeaderboardLiveTest do
       {:ok, _view, html} = live(conn, "/share/leaderboard?view=difficulty&difficulty=hard")
 
       # Check meta tags in the HTML
-      assert html =~ "Hard Difficulty Leaderboard - CodeRacer"
+      assert html =~ "Hard Difficulty Leaderboard - BalapKode"
       assert html =~ "Check out the top Hard difficulty coding speed champions"
       assert html =~ "/share/leaderboard?view=difficulty&amp;difficulty=hard"
       assert html =~ "/og-image/leaderboard?view=difficulty&amp;difficulty=hard"
@@ -102,7 +104,7 @@ defmodule CoderacerWeb.ShareLeaderboardLiveTest do
         live(conn, "/share/leaderboard?view=combined&language=elixir&difficulty=easy")
 
       # Check meta tags in the HTML
-      assert html =~ "Elixir (Easy) Leaderboard - CodeRacer"
+      assert html =~ "Elixir (Easy) Leaderboard - BalapKode"
       assert html =~ "Check out the top Elixir (Easy) coding speed champions"
       assert html =~ "/share/leaderboard?view=combined&amp;language=elixir&amp;difficulty=easy"
       assert html =~ "/og-image/leaderboard?view=combined&amp;language=elixir&amp;difficulty=easy"
@@ -127,8 +129,8 @@ defmodule CoderacerWeb.ShareLeaderboardLiveTest do
       {:ok, _view, html} = live(conn, "/share/leaderboard")
 
       assert html =~ "share-leaderboard"
-      assert html =~ "CodeRacer Leaderboard 🏆"
-      assert html =~ "Check out this CodeRacer leaderboard! 🏆"
+      assert html =~ "BalapKode Leaderboard 🏆"
+      assert html =~ "Check out this BalapKode leaderboard! 🏆"
       assert html =~ "Share"
     end
 

--- a/test/coderacer_web/live/share_live_test.exs
+++ b/test/coderacer_web/live/share_live_test.exs
@@ -21,8 +21,9 @@ defmodule CoderacerWeb.ShareLiveTest do
     test "renders share page with session results", %{conn: conn, session: session} do
       {:ok, _view, html} = live(conn, "/share/#{session.id}")
 
-      assert html =~ "CodeRacer Results"
       assert html =~ "Check out this coding challenge performance!"
+      assert html =~ "BalapKode"
+      refute html =~ "CodeRacer"
     end
 
     test "displays performance statistics correctly", %{conn: conn, session: session} do

--- a/test/coderacer_web/live/start_live_test.exs
+++ b/test/coderacer_web/live/start_live_test.exs
@@ -11,6 +11,8 @@ defmodule CoderacerWeb.StartLiveTest do
       assert html =~ "Programming Language"
       assert html =~ "Difficulty Level"
       assert html =~ "Start"
+      assert html =~ "BalapKode"
+      refute html =~ "CodeRacer"
     end
 
     test "mount assigns languages and difficulties", %{conn: conn} do


### PR DESCRIPTION
Rename "CodeRacer" to "BalapKode" across various components and tests to reflect the new branding. Update meta tags, titles, and share descriptions accordingly.

Solve issue #8 